### PR TITLE
feat: bump version of terragrunt to support terraform v1.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/runatlantis/atlantis:v0.19.6
+# Release notes: https://github.com/runatlantis/atlantis/releases/tag/v0.22.3
+FROM ghcr.io/runatlantis/atlantis:v0.22.3
 
 RUN apk add aws-cli jq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/runatlantis/atlantis:v0.19.6
 
 RUN apk add aws-cli jq
 
-RUN wget https://github.com/gruntwork-io/terragrunt/releases/download/v0.38.5/terragrunt_linux_amd64 && chmod +x terragrunt_linux_amd64 && mv terragrunt_linux_amd64 /usr/bin/terragrunt
+RUN wget https://github.com/gruntwork-io/terragrunt/releases/download/v0.42.1/terragrunt_linux_amd64 && chmod +x terragrunt_linux_amd64 && mv terragrunt_linux_amd64 /usr/bin/terragrunt
 
 WORKDIR /home/atlantis
 


### PR DESCRIPTION
Bumps terragrunt to 0.42.1 which includes support for terraform v1.3

https://terragrunt.gruntwork.io/docs/getting-started/supported-terraform-versions/