### PR TITLE
chore: remove need for aws, jq and others

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ ARG TERRAGRUNT_VERSION=${TERRAGRUNT_VERSION:-v0.56.2}
 # User root user to install additional packages
 USER root
 
-RUN apk add aws-cli jq
-
 RUN wget https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 && chmod +x terragrunt_linux_amd64 && mv terragrunt_linux_amd64 /usr/bin/terragrunt
 
 # Switch back to atlantis user


### PR DESCRIPTION
These were needed bc our workflow commands used them, but we are no longer using them and they just complicate the image.

Related PR: 